### PR TITLE
Add Playwright fallback for POST requests

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -185,6 +185,99 @@ async def _make_request_playwright(
     return None
 
 
+async def _make_request_playwright_post(
+    url: str,
+    site_key: str,
+    timeout: int = 30,
+    max_retries: int = 5,
+    data: Optional[Dict[str, Any]] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
+):
+    global browser
+    headers = await get_random_headers(site_key)
+    if extra_headers:
+        headers.update(extra_headers)
+
+    payload = {str(k): str(v) for k, v in (data or {}).items()}
+    last_exception: Exception | None = None
+
+    for attempt in range(1, max_retries + 1):
+        proxy_url = None
+        try:
+            if not browser:
+                await initialize_scraper(site_key)
+                if not browser:
+                    raise RuntimeError("Playwright browser not initialized")
+
+            proxy_settings = None
+            if USE_PROXY:
+                proxy_url = get_proxy_url(GLOBAL_PROXY_USERNAME, GLOBAL_PROXY_PASSWORD)
+                if proxy_url:
+                    from urllib.parse import urlparse
+
+                    p = urlparse(proxy_url)
+                    proxy_settings = {"server": f"{p.scheme}://{p.hostname}:{p.port}"}
+                    if p.username:
+                        proxy_settings["username"] = p.username
+                    if p.password:
+                        proxy_settings["password"] = p.password
+
+            context = await get_context(proxy_settings, headers)
+
+            referer = (extra_headers or {}).get("Referer")
+            if referer:
+                page = await context.new_page()
+                try:
+                    await page.goto(referer, timeout=timeout * 1000)
+                    try:
+                        await page.wait_for_load_state("networkidle", timeout=timeout * 1000)
+                    except Exception:
+                        pass
+                finally:
+                    try:
+                        await page.close()
+                    except Exception:
+                        pass
+
+            request_headers = dict(headers)
+            request_headers.setdefault("X-Requested-With", "XMLHttpRequest")
+            request_headers.setdefault("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+
+            response = await context.request.post(
+                url,
+                data=payload,
+                headers=request_headers,
+                timeout=timeout * 1000,
+            )
+            text = await response.text()
+            status = response.status
+
+            if status == 200 and text and not is_anti_bot_content(text):
+                return text
+
+            logger.warning(
+                f"[playwright][POST] Potential anti-bot or bad status for {url} (status: {status})"
+            )
+            if USE_PROXY and proxy_settings and proxy_url and should_blacklist_proxy(proxy_url, LOADED_PROXIES):
+                await mark_bad_proxy(proxy_url)
+                await release_context(proxy_settings)
+            await asyncio.sleep(random.uniform(1, 3))
+        except Exception as ex:
+            last_exception = ex
+            logger.warning(f"[make_request][POST] Lỗi lần {attempt} khi truy cập {url}: {ex}")
+            if USE_PROXY and proxy_settings and proxy_url and should_blacklist_proxy(proxy_url, LOADED_PROXIES):
+                await remove_bad_proxy(proxy_url)
+                await release_context(proxy_settings)
+            await asyncio.sleep(random.uniform(1, 3))
+        finally:
+            await recycle_idle_contexts()
+
+    if last_exception:
+        logger.error(f"[make_request][POST] Playwright exhausted retries for {url}: {last_exception}")
+
+    return None
+
+
 async def make_request(
     url: str,
     site_key: str,
@@ -198,13 +291,35 @@ async def make_request(
     """Try httpx first then fallback to Playwright when blocked."""
     if method.upper() == 'POST':
         resp = await fetch(url, site_key, timeout, method=method, data=data, extra_headers=extra_headers)
+        fallback_stats["httpx_success"].setdefault(site_key, 0)
+        fallback_stats["fallback_count"].setdefault(site_key, 0)
         if resp and resp.status_code == 200:
             class R:
                 def __init__(self, text):
                     self.text = text
+
+            fallback_stats["httpx_success"][site_key] += 1
             return R(resp.text)
-        logger.error(f"[{site_key}] POST request to {url} failed with httpx and has no Playwright fallback.")
-        return None
+
+        logger.warning(f"[{site_key}] POST request to {url} failed with httpx. Trying Playwright fallback.")
+        fallback_stats["fallback_count"][site_key] += 1
+        text = await _make_request_playwright_post(
+            url,
+            site_key,
+            timeout=timeout,
+            max_retries=max_retries,
+            data=data or {},
+            extra_headers=extra_headers or {},
+        )
+        if text is None:
+            logger.error(f"[{site_key}] POST request to {url} failed with httpx and Playwright fallback.")
+            return None
+
+        class R:
+            def __init__(self, text):
+                self.text = text
+
+        return R(text)
 
     resp = await fetch(url, site_key, timeout, extra_headers=extra_headers)
     fallback_stats["httpx_success"].setdefault(site_key, 0)


### PR DESCRIPTION
## Summary
- add a Playwright-based fallback helper to handle POST requests that are blocked by httpx
- extend the generic make_request flow to retry POST requests with the new fallback and update fallback statistics

## Testing
- pytest *(fails: missing optional dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d89f19490c83299e0e24915ea1bd13