### PR TITLE
Return HTML string for XTruyen chapter content

### DIFF
--- a/adapters/xtruyen_adapter.py
+++ b/adapters/xtruyen_adapter.py
@@ -192,7 +192,15 @@ class XTruyenAdapter(BaseSiteAdapter):
         html = await self._fetch_text(chapter_url, wait_for_selector="#chapter-reading-content")
         if not html:
             return None
-        content = parse_chapter_content(html)
-        if not content:
+
+        parsed = parse_chapter_content(html)
+        if not parsed:
+            logger.warning(f"[{self.site_key}] Unable to parse content for chapter '{chapter_title}'")
+            return None
+
+        content_html = parsed.get('content') if isinstance(parsed, dict) else None
+        if not content_html or not content_html.strip():
             logger.warning(f"[{self.site_key}] Empty content for chapter '{chapter_title}'")
-        return content
+            return None
+
+        return content_html

--- a/tests/test_xtruyen_adapter.py
+++ b/tests/test_xtruyen_adapter.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+
+from adapters.xtruyen_adapter import XTruyenAdapter
+
+
+@pytest.mark.asyncio
+async def test_get_chapter_content_returns_html(monkeypatch):
+    adapter = XTruyenAdapter()
+    sample_html = Path('tmp_data/xtruyen/content_chapter.txt').read_text(encoding='utf-8')
+
+    async def fake_fetch(self, url, wait_for_selector=None):
+        return sample_html
+
+    monkeypatch.setattr(XTruyenAdapter, '_fetch_text', fake_fetch)
+
+    content = await adapter.get_chapter_content('https://example.com/chapter-1', 'Chương 1', 'xtruyen')
+
+    assert isinstance(content, str)
+    assert 'Nửa đêm canh ba' in content
+    assert '<p>' in content


### PR DESCRIPTION
## Summary
- ensure the XTruyen adapter returns the parsed chapter HTML string so downstream consumers save the actual content
- add a regression test that patches the adapter fetcher and verifies the decompressed chapter includes text and paragraph tags

## Testing
- pytest tests/test_xtruyen_adapter.py -q *(fails: ModuleNotFoundError: No module named 'bs4')*


------
https://chatgpt.com/codex/tasks/task_e_68d8a9fba5a88329a25735690bd339d2