### PR TITLE
Handle xtruyen chapter ajax nonce

### DIFF
--- a/adapters/xtruyen_adapter.py
+++ b/adapters/xtruyen_adapter.py
@@ -154,6 +154,11 @@ class XTruyenAdapter(BaseSiteAdapter):
 
         ajax_url = f"{self.base_url}/wp-admin/admin-ajax.php"
         form_data = {'action': 'manga_get_chapters', 'manga': post_id}
+
+        ajax_nonce = details.get('ajax_nonce')
+        if ajax_nonce:
+            form_data['security'] = ajax_nonce
+            form_data.setdefault('nonce', ajax_nonce)
         
         headers = {
             'X-Requested-With': 'XMLHttpRequest',

--- a/tests/test_xtruyen_parse.py
+++ b/tests/test_xtruyen_parse.py
@@ -23,11 +23,12 @@ class TestXTruyenParse(unittest.TestCase):
     def test_parse_story_info(self):
         self.assertIsNotNone(self.detail_story_html, "detail_story.txt not found")
         story_info = parse_story_info(self.detail_story_html)
-        
+
         self.assertEqual(story_info['title'], 'THỜI BUỔI NÀY AI CÒN ĐƯƠNG ĐỨNG ĐẮN HỒ YÊU')
         self.assertEqual(story_info['author'], 'Ngã Lai Tạng Ba Binh Tuyến')
         self.assertTrue(story_info['description'].startswith('Ta kêu Trần Nguyên'))
         self.assertEqual(story_info['post_id'], '10235224')
+        self.assertEqual(story_info['ajax_nonce'], 'fee264d54b')
 
     def test_parse_chapter_content(self):
         self.assertIsNotNone(self.content_chapter_html, "content_chapter.txt not found")


### PR DESCRIPTION
## Summary
- extract and store the XTruyen AJAX nonce when parsing story details
- include the nonce when requesting the full chapter list so AJAX requests are accepted
- extend the parser test to cover the captured nonce

## Testing
- pytest tests/test_xtruyen_parse.py *(fails: fixture HTML files are missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f7ecf9508329ba07352e9100af3d