### PR TITLE
Fix directory creation permissions

### DIFF
--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -23,7 +23,12 @@ async def ensure_directory_exists(dir_path: str) -> bool:
     exists = await loop.run_in_executor(None, os.path.exists, dir_path)
     if not exists:
         try:
-            await loop.run_in_executor(None, os.makedirs, dir_path, True)
+            # Use exist_ok=True to avoid creating directories with incorrect
+            # permissions (passing ``True`` positionally sets the mode).
+            await loop.run_in_executor(
+                None,
+                lambda: os.makedirs(dir_path, exist_ok=True),
+            )
             logger.info(f"Đã tạo thư mục: {dir_path}")
             return True
         except Exception as e:


### PR DESCRIPTION
## Summary
- ensure ensure_directory_exists uses os.makedirs with exist_ok=True instead of passing positional True as the mode
- document the change to avoid future permission issues when creating completion directories

## Testing
- python -m pytest -q *(fails: missing pytest-asyncio plugin in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d93925516083299e4ccebad1b5ad87